### PR TITLE
2nd attempt: silence warnings about illegal reflective access operations

### DIFF
--- a/aspect/BUILD.aspect
+++ b/aspect/BUILD.aspect
@@ -19,6 +19,13 @@ java_import(
 
 java_binary(
     name = "PackageParser_bin",
+    jvm_flags = [
+        # quiet warnings from com.google.protobuf.UnsafeUtil,
+        # see: https://github.com/google/protobuf/issues/3781
+        "-XX:+IgnoreUnrecognizedVMOptions",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
     main_class = "com.google.idea.blaze.aspect.PackageParser",
     runtime_deps = [":package_parser_lib"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Take 2 of https://github.com/bazelbuild/intellij/pull/433. In turn https://github.com/bazelbuild/bazel/issues/6151#issuecomment-432774820. 

IIUC the change needs to happen in a different BUILD file. One that gets packaged with the plugin. `BUILD.aspect` is renamed and eventually installed at `/Users/$USER/Library/Application\ Support/IntelliJIdea2018.3/ijwb/aspect/BUILD.bazel` on osx.

This way the arguments are passed when the aspect launches `PackageParser` via bazel launched by the IJ plugin. And we don't get the warnings in the IJ bazel console.
```
/usr/local/bin/bazel build ... --aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect --override_repository=intellij_aspect=/Users/$HOME/Library/Application Support/IntelliJIdea2018.3/ijwb/aspect ... -- //...
```